### PR TITLE
[BUGFIX] Decorate version information with double quotes

### DIFF
--- a/public/assets/JavaScript/composerHelper.js
+++ b/public/assets/JavaScript/composerHelper.js
@@ -67,7 +67,7 @@ const vanillaAjaxForm = function(form) {
                     if(response.status[composerPackage] === true) {
                         showOutput = true;
                         if (response.status['typo3_version']) {
-                            composerPackage = composerPackage + ':' + response.status['typo3_version'];
+                            composerPackage = '"' + composerPackage + ':' + response.status['typo3_version'] + '"';
                         }
                         outputContainer.insertAdjacentText('beforeend', ' ' + composerPackage)
                     }

--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -23,9 +23,9 @@
                         <div class="accordion-content-item accordion-content-text">
 
                             {% if lts %}
-                                <pre><code>composer create-project typo3/cms-base-distribution my-new-project ^{{ lts }}</code></pre>
+                                <pre><code>composer create-project typo3/cms-base-distribution "my-new-project:^{{ lts }}"</code></pre>
                             {% else %}
-                                <pre><code>composer create-project typo3/cms-base-distribution my-new-project ^{{ version }}</code></pre>
+                                <pre><code>composer create-project typo3/cms-base-distribution "my-new-project:^{{ version }}"</code></pre>
                             {% endif %}
                             <p>If you are experienced with composer you can create your own composer.json and select the needed packages of TYPO3 via this helper: <a href="{{ path('composer-helper') }}" title="Composer Helper">Composer Helper</a></p>
 


### PR DESCRIPTION
On Windows ^ has a special meaning and therefor versions have to be decorated
by double quotes which is compatible with all platforms.

Fixes #75