### PR TITLE
[TASK] Add route for composer.typo3.org

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -7,7 +7,8 @@ webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"
 xdebug_enabled: false
-additional_hostnames: []
+additional_hostnames:
+- composer.typo3.org
 additional_fqdns: []
 mariadb_version: "10.2"
 nfs_mount_enabled: false

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -12,6 +12,7 @@ additional_fqdns: []
 mariadb_version: "10.2"
 nfs_mount_enabled: false
 provider: default
+omit_containers: [db, dba]
 use_dns_when_possible: true
 timezone: ""
 

--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,24 @@
+# This file is a "template" of which env vars need to be defined for your application
+# Copy this file to .env file for development, create environment variables when deploying to production
+# https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
+
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=418b0ae1e3161f945005b4220a786a49
+APP_DOMAIN=typo3.org.ddev.site
+#TRUSTED_PROXIES=127.0.0.1,127.0.0.2
+#TRUSTED_HOSTS=localhost,example.com
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+# Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+# Configure your db driver and server_version in config/packages/doctrine.yaml
+DATABASE_URL=sqlite:///%kernel.project_dir%/var/gettr.db
+###< doctrine/doctrine-bundle ###
+
+###> nelmio/cors-bundle ###
+CORS_ALLOW_ORIGIN=^https?://get\.typo3\.org\.ddev\.site:?[0-9]*$
+###< nelmio/cors-bundle ###
+
+BASE_URL=https://get.typo3.org.ddev.site

--- a/.env.dist
+++ b/.env.dist
@@ -5,6 +5,7 @@
 ###> symfony/framework-bundle ###
 APP_ENV=prod
 APP_SECRET=418b0ae1e3161f945005b4220a786a49
+APP_DOMAIN=typo3.org
 #TRUSTED_PROXIES=127.0.0.1,127.0.0.2
 #TRUSTED_HOSTS=localhost,example.com
 ###< symfony/framework-bundle ###

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 !/bin/
 /bin/*
 !/bin/console
+/public/p/*
+/public/packages.json
+/public/satis.html
 
 ###> symfony/framework-bundle ###
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.ddev/commands/
 .idea/
 .vscode/
 *.cache

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,6 +1,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
+    app.domain: '%env(APP_DOMAIN)%'
 
 services:
     # default configuration for services in *this* file

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -45,7 +45,6 @@ class DefaultController extends AbstractController
         $this->composerPackagesService = $composerPackagesService;
     }
 
-
     /**
      * @Route("/", methods={"GET"}, name="composer-root", condition="context.getHost() matches '/composer.%app.domain%/'")
      */

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -45,13 +45,22 @@ class DefaultController extends AbstractController
         $this->composerPackagesService = $composerPackagesService;
     }
 
+
+    /**
+     * @Route("/", methods={"GET"}, name="composer-root", condition="context.getHost() matches '/composer.%app.domain%/'")
+     */
+    public function composerRoot(): Response
+    {
+        return $this->composerRepository();
+    }
+
     /**
      * @Route("/", methods={"GET"}, name="root")
      * @Cache(expires="tomorrow", public=true)
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function show(Request $request)
+    public function show(Request $request): Response
     {
         $majorVersionRepository = $this->getDoctrine()->getRepository(MajorVersion::class);
         $communityVersions = $majorVersionRepository->findAllActiveCommunity();
@@ -280,16 +289,6 @@ class DefaultController extends AbstractController
     }
 
     /**
-     * @Route("/misc/composer/repository", methods={"GET"}, name="composer-repository")
-     */
-    public function composerRepository(): Response
-    {
-        $templateName = 'default/composer-repository.html.twig';
-
-        return $this->render($templateName);
-    }
-
-    /**
      * @Route("/ajax/composer/helper/generate", methods={"POST"}, name="ajax-composer-helper-generate")
      * @param Request $request
      * @return JsonResponse
@@ -309,6 +308,16 @@ class DefaultController extends AbstractController
         }
 
         return new JsonResponse(['status' => $formData]);
+    }
+
+    /**
+     * @Route("/misc/composer/repository", methods={"GET"}, name="composer-repository")
+     */
+    public function composerRepository(): Response
+    {
+        $templateName = 'default/composer-repository.html.twig';
+
+        return $this->render($templateName);
     }
 
     /**


### PR DESCRIPTION
This patch is a preparation of the move of composer.typo3.org to this site.

**Important: .env needs new var APP_DOMAIN=typo3.org**

We have to discuss the .env handling in general, this should be added to the repo imho see https://symfony.com/doc/current/configuration.html#configuring-environment-variables-in-env-files