### PR TITLE
[TASK] Update min compatible MySQL version for TYPO3 v10

### DIFF
--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -50,7 +50,7 @@
                             <ul class="list-info">
                                 {% if version.version == 10 %}
                                     <li>PHP 7.2 or later</li>
-                                    <li>MySQL 5.7+ / MariaDB / Postgres / SQLite support</li>
+                                    <li>MySQL 5.5+ / MariaDB / Postgres / SQLite support</li>
                                     <li>Modern Browsers</li>
                                 {% elseif version.version == 9 %}
                                     <li>PHP 7.2 or later</li>


### PR DESCRIPTION
The minimum required MySQL version has been adjusted from version 5.7 to
version 5.5. This patch updates the requirements listed on the landing
page.

Resolves #89