### PR TITLE
[TASK] Update details about TYPO3 v10 LTS at the AWS Marketplace (#161)

### DIFF
--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -187,7 +187,7 @@
                     <div class="card-body">
                         <p>Ready-to-use machine images with TYPO3 pre-installed and pre-configured.
                             A &quot;root&quot; login via SSH and an administrator account to the TYPO3 backend allow
-                            unrestricted access to the server and CMS. TYPO3 v7, v8, v9 LTS and v10 sprint releases
+                            unrestricted access to the server and CMS. TYPO3 v7, v8, v9, and v10 LTS releases
                             are available.</p>
                     </div>
                     <div class="card-footer">


### PR DESCRIPTION
As of today, the LTS version of TYPO3 v10 is available as a ready-to-use machine image at the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/B07W2ZPW5P?ref_=srh_res_product_title).

This change updates the wording on the landing page from "v10 sprint releases" to "LTS".

Resolves #161