### PR TITLE
[BUGFIX] Block abusing IP 212.95.122.212

### DIFF
--- a/cnf/nginx.conf
+++ b/cnf/nginx.conf
@@ -51,9 +51,7 @@ location ~ (?!^\/\.well-known)\/\. {
 # Custom configuration
 
 # Block abusing IPs
-location / {
-  deny 212.95.122.212;
-}
+deny 212.95.122.212;
 
 # Allow access to packages.json
 modsecurity_rules 'SecRuleRemoveById 930130';


### PR DESCRIPTION
We get 10 request per second from this IP to the API for invalid versions beginning with version 4 and incrementing up to about 400.000