### PR TITLE
[BUGFIX] Deploy .env as required by Symfony 5.1

### DIFF
--- a/.mage.yml
+++ b/.mage.yml
@@ -11,9 +11,9 @@ magephp:
         - bin/phpunit
         - tests
         - .editorconfig
-        - .env
         - .env.ddev
         - .env.local
+        - .env.test
         - .gitattributes
         - .gitignore
         - .gitmodules


### PR DESCRIPTION
This change includes the .env in the deployment and excludes the
.env.test instead as required by Symfony 5.1.