### PR TITLE
Update details about TYPO3 LTS and sprint releases at the AWS Marketplace

### DIFF
--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -191,8 +191,8 @@
                     <div class="card-body">
                         <p>Ready-to-use machine images with TYPO3 pre-installed and pre-configured.
                             A &quot;root&quot; login via SSH and an administrator account to the TYPO3 backend allow
-                            unrestricted access to the server and CMS. TYPO3 v7, v8, v9, and v10 LTS releases
-                            are available.</p>
+                            unrestricted access to the server and TYPO3. All current TYPO3 LTS-releases as well as
+                            v11 sprint releases are available.</p>
                     </div>
                     <div class="card-footer">
                         <a href="https://aws.amazon.com/marketplace/seller-profile/?id=3c5e5f3c-d60e-4405-a9ca-aae8abfa3e2b" class="btn btn-primary">


### PR DESCRIPTION
As of today, we also offer TYPO3 v11 machine images as a new product at the AWS Marketplace (see [TYPO3 v11.x CMS](https://aws.amazon.com/marketplace/pp/B08R9BXG5Y)).

This change updates the wording on the landing page to reflect the new version(s).

Resolves #227