### PR TITLE
[TASK] Update details about LTS and sprint releases at the AWS Marketplace

### DIFF
--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -196,8 +196,7 @@
                     <div class="card-body">
                         <p>Ready-to-use machine images with TYPO3 pre-installed and pre-configured.
                             A &quot;root&quot; login via SSH and an administrator account to the TYPO3 backend allow
-                            unrestricted access to the server and TYPO3. All current TYPO3 LTS-releases as well as
-                            v11 sprint releases are available.</p>
+                            unrestricted access to the server and TYPO3. All current TYPO3 LTS-releases are available.</p>
                     </div>
                     <div class="card-footer">
                         <a href="https://aws.amazon.com/marketplace/seller-profile/?id=3c5e5f3c-d60e-4405-a9ca-aae8abfa3e2b" class="btn btn-primary">


### PR DESCRIPTION
As of today, the LTS version of TYPO3 v11 is available as a ready-to-use machine image at the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-v6w33h2oatsyk).

This change updates the wording on the landing page and removes the term "sprint releases".