### PR TITLE
[TASK] Update links to documentation

### DIFF
--- a/src/Entity/Embeddables/ReleaseNotes.php
+++ b/src/Entity/Embeddables/ReleaseNotes.php
@@ -54,7 +54,7 @@ class ReleaseNotes
      * @ORM\Column(type="text", nullable=true)
      * @Serializer\Groups({"putcontent", "content"})
      * @Serializer\Type("string")
-     * @SWG\Property(description="Ugrade instructions - supports markdown (github flavored)", example="The [usual upgrading procedure](https:\/\/docs.typo3.org\/typo3cms\/InstallationGuide\/) applies.\nNo database updates are necessary.\n")
+     * @SWG\Property(description="Ugrade instructions - supports markdown (github flavored)", example="The [usual upgrading procedure](https:\/\/docs.typo3.org\/upgrade) applies.\nNo database updates are necessary.\n")
      */
     private ?string $upgradingInstructions = null;
 

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -95,7 +95,7 @@ class MenuBuilder extends TemplateMenuBuider
         $menu->addChild(
             'install',
             [
-                'uri' => 'https://docs.typo3.org/typo3cms/InstallationGuide/',
+                'uri' => 'https://docs.typo3.org/installation',
                 'label' => 'Installation Guide'
             ]
         );

--- a/templates/default/composer.html.twig
+++ b/templates/default/composer.html.twig
@@ -14,15 +14,15 @@
     {% frame with { color: 'light' } %}
         <h2>How to use it?</h2>
         <p>As a quick way to use Composer, the Base Distribution can be downloaded. It is assuming you have Composer already <a href="https://getcomposer.org/download/" target="_blank" rel="noopener">installed</a>
-        on your system. Detailed informations are available in the <a href="https://docs.typo3.org/m/typo3/guide-installation/master/en-us/QuickInstall/Composer/Index.html">TYPO3 Documentation</a>.</p>
+        on your system. Detailed information is available in the <a href="https://docs.typo3.org/installation">TYPO3 Documentation</a>.</p>
         <p>For an easy customized setup of the core extensions for your project's <code>composer.json</code>, use the <a href="composer/helper">TYPO3 Composer Helper</a>.</p>
         <p>It is recommended to include extensions directly from <a href="{{ packagist.search }}" target="_blank" rel="noopener">Packagist</a> instead of using the <a href="composer/repository">TYPO3 Composer Repository</a>. For example, better require <code>georgringer/news</code> than <code>typo3-ter/news</code>, if you want the News extension in your Composer installation.</p>
     {% endframe %}
 
     {% frame %}
         <h2>Add composer.json to your extensions</h2>
-        <p>It is encouraged to add your own <code>composer.json</code> file in your extension to be on the good side, as TYPO3 CMS will rely more and more on Composer to handle dependencies. The file must be placed at the root of your extension, follow the instructions of the <a href="https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html">TYPO3 Documentation</a>.</p>
-        <p>Once you added a composer.json file, it is highly recommended to register your extensions on <a href="{{ packagist.submit }}" target="_blank" rel="noopener">Packagist</a>.</p>
+        <p>Add your own <code>composer.json</code> file to your extension. The file must be placed at the root of your extension, follow the instructions of the <a href="https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html">TYPO3 Documentation</a>.</p>
+        <p>Once you have added a composer.json file, it is recommended to register your extensions on <a href="{{ packagist.submit }}" target="_blank" rel="noopener">Packagist</a>.</p>
     {% endframe %}
 
 {% endblock %}

--- a/templates/default/partials/version/package-signatures.html.twig
+++ b/templates/default/partials/version/package-signatures.html.twig
@@ -2,9 +2,9 @@
     {% frame with { id: 'package-signatures', title: 'Package Signatures - Verifying integrity of releases' } %}
         <p>
             TYPO3 Release Packages (the downloadable tarballs and zip files) as well as Git tags are signed
-            using PGP signatures since TYPO3 v7 during the automated release process. Besides that, MD5 and SHA2-256 hashes are
+            using PGP signatures since TYPO3 v7 during the automated release process. Besides that, SHA1 and SHA2-256 hashes are
             being generated for these files. Find more details on verifying signatures and hashes in the
-            <a href="https://docs.typo3.org/m/typo3/guide-installation/master/en-us/ReleaseIntegrity/Index.html">infrastructure guide</a>.
+            <a href="https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/Installation/ReleaseIntegrity.html">infrastructure guide</a>.
         </p>
     {% endframe %}
 {% endif %}

--- a/templates/default/partials/version/signatures.html.twig
+++ b/templates/default/partials/version/signatures.html.twig
@@ -4,7 +4,7 @@
             TYPO3 Release Packages (the downloadable tarballs and zip files) as well as Git tags are signed
             using PGP signatures during the automated release process. Besides that, MD5 and SHA2-256 hashes are
             being generated for these files. Find more details on verifying signatures and hashes in the
-            <a href="https://docs.typo3.org/m/typo3/guide-installation/master/en-us/ReleaseIntegrity/Index.html">infrastructure guide</a>.
+            <a href="https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/Installation/ReleaseIntegrity.html">infrastructure guide</a>.
         </p>
         <p>
             <a href="https://typo3.azureedge.net/typo3/{{ current.version }}/README.md">

--- a/templates/default/partials/version/system-requirements.html.twig
+++ b/templates/default/partials/version/system-requirements.html.twig
@@ -1,5 +1,5 @@
 {% frame with { id: 'system-requirements', color: 'light', title: 'System Requirements' } %}
-    <p>For more information as well as installation instructions see the <a href="https://docs.typo3.org/m/typo3/guide-installation/master/en-us/In-depth/SystemRequirements/Index.html" rel="noopener,noreferrer">Installation guide</a>.</p>
+    <p>For more information as well as installation instructions see the <a href="https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/SystemRequirements/Index.html" rel="noopener,noreferrer">Installation guide</a>.</p>
     <div class="card">
         <div class="datatable">
             <table class="datatable-table">


### PR DESCRIPTION
Even though (most of) the links are currently working
thanks to existing redirects, get.typo3.org should use
up-to-date links.