### PR TITLE
[TASK] Deploy with Composer snapshot

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,7 +33,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          tools: composer:v2, andres-montanez/magallanes
+          tools: composer:snapshot, andres-montanez/magallanes
       - name: Get Environment
         id: environment
         run: |


### PR DESCRIPTION
Composer 2.3.0 introduced a regression which makes Magallanes to fail
but should be fixed with the snapshot version.