### PR TITLE
[TASK] Avoid sync issues with DDEV

### DIFF
--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -28,7 +28,8 @@
                                 <p><a href="https://ddev.readthedocs.io/en/stable/" title="DDEV Local Documentation" target="_blank" rel="noopener">DDEV Local</a> simplifies integrating the power and consistency of containerization into your workflows. Set up environments in minutes; switch contexts and projects quickly and easily; speed your time to deployment. DDEV handles the complexity. You get on with the valuable part of your job.</p>
                                 <p>In a new project folder using your favorite shell, run these lines:</p>
                                 <pre><code>ddev config --project-type=typo3 --docroot=public --create-docroot
-ddev composer create "typo3/cms-base-distribution:^{{ package_version }}"
+ddev composer create --no-install "typo3/cms-base-distribution:^{{ package_version }}"
+ddev composer install
 ddev typo3cms install:setup
 ddev launch</code></pre>
                                 <div class="alert alert-warning" role="alert">


### PR DESCRIPTION
When using mutagen, synchronizing the files back from the temporary folder
may lead to issues. Doing the Composer installation in a dedicated step
will avoid these issues. See also DDEV Discord
https://discord.com/channels/664580571770388500/998637116919664691