### PR TITLE
[TASK] DDEV deploy command for dev deployment

### DIFF
--- a/.ddev/commands/host/deploy
+++ b/.ddev/commands/host/deploy
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## Description: Deploy site
+## Usage: deploy
+## Example: "ddev deploy"
+
+ddev auth ssh --ssh-key-path .ssh
+ddev composer global require --ansi -n --no-progress andres-montanez/magallanes
+ddev exec -- mkdir -p ./.mage/logs
+ddev composer global exec --ansi -n mage deploy develop
+ddev composer install --ansi -n --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.ddev/docker-compose.tmpfs.yaml
 /.idea/
+/.mage/
 /.vscode/
 /public/p/
 /public/p2/

--- a/.mage.yml
+++ b/.mage.yml
@@ -3,36 +3,25 @@ magephp:
     composer:
         path: composer
     exclude:
-        - .ddev
-        - .git
-        - .github
-        - .mage
-        - .vscode
-        - bin/phpunit
-        - stubs
-        - tests
-        - .editorconfig
-        - .env.ddev
-        - .env.local
-        - .env.test
-        - .gitattributes
-        - .gitignore
-        - .gitmodules
-        - .mage.yml
-        - .php-cs-fixer.cache
-        - .php-cs-fixer.dist.php
-        - .phplint-cache
-        - .phplint.yml
-        - .phpunit.result.cache
-        - LICENSE
-        - phpstan.neon
-        - phpunit.xml.dist
-        - README.md
-        - rector.php
+        - ./.*
+        - ./public/p
+        - ./public/p2
+        - ./public/aliases.json
+        - ./public/packages.json
+        - ./public/satis.html
+        - ./stubs
+        - ./tests
+        - ./tools
+        - ./var
+        - ./LICENSE
+        - ./phpstan.neon
+        - ./phpunit.xml.dist
+        - ./README.md
+        - ./rector.php
     environments:
         develop:
             user: get-dev
-            from: ./
+            from: ./* ./.env
             host_path: ./site/mage/
             releases: 3
             hosts:
@@ -42,6 +31,7 @@ magephp:
                 - composer/install: { flags: '--no-dev --no-progress --optimize-autoloader' }
                 - composer/install: { flags: '--no-dev --no-progress --optimize-autoloader --working-dir=satis' }
             on-deploy:
+                - exec: { cmd: 'mkdir -p var', desc: 'Create var folder' }
                 - fs/link: { from: "../../../shared/.env.local", to: ".env.local" }
                 - fs/link: { from: "../../../../shared/public/p", to: "public/p" }
                 - fs/link: { from: "../../../../shared/public/p2", to: "public/p2" }
@@ -61,7 +51,7 @@ magephp:
             post-deploy:
         production:
             user: get
-            from: ./
+            from: ./* ./.env
             host_path: ./site/mage/
             releases: 3
             hosts:
@@ -71,6 +61,7 @@ magephp:
                 - composer/install: { flags: '--no-dev --no-progress --optimize-autoloader' }
                 - composer/install: { flags: '--no-dev --no-progress --optimize-autoloader --working-dir=satis' }
             on-deploy:
+                - exec: { cmd: 'mkdir -p var', desc: 'Create var folder' }
                 - fs/link: { from: "../../../shared/.env.local", to: ".env.local" }
                 - fs/link: { from: "../../../../shared/public/p", to: "public/p" }
                 - fs/link: { from: "../../../../shared/public/p2", to: "public/p2" }
@@ -90,7 +81,7 @@ magephp:
             post-deploy:
         stage:
             user: get-stage
-            from: ./
+            from: ./* ./.env
             host_path: ./site/mage/
             releases: 3
             hosts:

--- a/.ssh/.gitignore
+++ b/.ssh/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore


### PR DESCRIPTION
Allows the deployment from local to get.typo3.dev with the new DDEV
custom command `ddev deploy`. Before a valid private key must be copied
to `.ssh`.