### PR TITLE
[TASK] Harden Nginx configuration

### DIFF
--- a/cnf/nginx.conf
+++ b/cnf/nginx.conf
@@ -63,5 +63,49 @@ modsecurity_rules 'SecRuleRemoveById 930130';
 # Allow DELETE method
 modsecurity_rules 'SecRuleRemoveById 911100';
 
-# Enable Symfony routing
-try_files $uri $uri/ /index.php$is_args$args;
+
+###############################################################################
+# Symfony routing configuration
+
+# try to serve file directly, fallback to Symfony
+location / {
+  try_files $uri @symfony;
+}
+
+# Directly return 404 for not found static resources
+location /assets {
+  try_files $uri =404;
+}
+
+location /bundles {
+  try_files $uri =404;
+}
+
+location /p {
+  try_files $uri =404;
+}
+
+location /p2 {
+  try_files $uri =404;
+}
+
+# Block access to satis folder
+location /satis {
+  satisfy all;
+  deny all;
+}
+
+# Allow access to /index.php and forward to default PHP configuration
+location ~ ^/index\.php(/|$) {
+  try_files /dev/null @php81;
+}
+
+# Block access to other .php files
+location ~ \.php$ {
+  return 404;
+}
+
+# Symfony routing configuration, add path as arguments to /index.php
+location @symfony {
+  try_files /dev/null /index.php$is_args$args;
+}


### PR DESCRIPTION
- only /index.php is allowed for execution, other scripts are denied
- for non existing static files from assets, bundles or Satis a 404 is
  returned directly without rely on the Symfony error handler
- access to /satis is blocked