### PR TITLE
[BUGFIX] Don't allow direct calls to index.php

### DIFF
--- a/cnf/nginx.conf
+++ b/cnf/nginx.conf
@@ -98,6 +98,7 @@ location /satis {
 # Allow access to /index.php and forward to default PHP configuration
 location ~ ^/index\.php(/|$) {
   try_files /dev/null @php81;
+  internal;
 }
 
 # Block access to other .php files


### PR DESCRIPTION
A discussion with @ohader today revealed a potential problem, as direct calls to index.php are also allowed, e.g. `https://get.typo3.dev/index.php/version/11` instead of `https://get.typo3.dev/version/11`, and thus the same page can be reached under multiple URIs and this could allow path traversals. This is now forbidden with this patch.