### PR TITLE
[BUGFIX] Fix Denglish wording reg. hosting

### DIFF
--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -90,7 +90,7 @@
                                 <h2 class="h5 alert-heading">PHP 8.x support</h2>
                                 <p class="mb-0">
                                     Please note, PHP 8.0 and above will not be supported by the v10 LTS releases! You
-                                    have to upgrade your installation to v11 or talk to your hoster regarding enhanced
+                                    have to upgrade your installation to v11 or talk to your hosting provider regarding enhanced
                                     PHP 7.4 support after November 2022.
                                 </p>
                             </div>


### PR DESCRIPTION
The word "hoster" is Denglish in this context and is an English slang word. The wording is changed to "hosting provider".