### PR TITLE
[BUGFIX] Provide PHP version

### DIFF
--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -14,6 +14,8 @@
             {% if version == 12 %}
                 {% set php_version_option = " --php-version 8.1" %}
                 {% set console = false %}
+            {% elseif version <= 10 %}
+                {% set php_version_option = " --php-version 7.4" %}
             {% endif %}
             <div class="accordion-item card">
                 <div class="accordion-header card-header" id="accordion-heading-ddev">


### PR DESCRIPTION
Latest DDEV uses PHP 8.0 as default so we have to provide a compatible
PHP version for v10 and below.

Fixes #404