### PR TITLE
[BUGFIX] Fix major version detection for package signatures

### DIFF
--- a/templates/default/partials/version/signatures.html.twig
+++ b/templates/default/partials/version/signatures.html.twig
@@ -1,4 +1,4 @@
-{% if current.version  >= 7  %}
+{% if current.majorVersion.version >= 7 %}
     {% frame with { id: 'package-signatures', title: 'Package Signatures' } %}
         <p>
             TYPO3 Release Packages (the downloadable tarballs and zip files) as well as Git tags are signed


### PR DESCRIPTION
Comparing a version like `"12.4.8"` with `7` will result in a string comparsion instead of the (intended) float/int comparison. That is because "12.4.8" can not be implicitly converted to a float as it contains more than one dot.

Note that "12.4.8" >= 7 is thus equal to `(bool)strcmp("12.4.8", "7")` which itself yields to false as `"1"` is string compared to `"7"` and is thus lower.