### PR TITLE
[BUGFIX] Fix instructions for running Typo3 version 13 using ddev

### DIFF
--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -11,8 +11,8 @@
             {% endif %}
             {% set php_version_option = "" %}
             {% set console = true %}
-            {% if version == 12 %}
-                {% set php_version_option = " --php-version 8.1" %}
+            {% if version >= 12 %}
+                {% set php_version_option = " --php-version 8.2" %}
                 {% set console = false %}
             {% elseif version <= 10 %}
                 {% set php_version_option = " --php-version 7.4" %}
@@ -39,7 +39,7 @@
                                 <pre><code>ddev config --project-type=typo3 --docroot=public --create-docroot{{ php_version_option }}
 ddev composer create --no-install "typo3/cms-base-distribution:^{{ package_version }}"
 ddev composer install
-{% if version == 12 %}
+{% if version >= 12 %}
 ddev restart
 {% endif %}
 {% if console %}


### PR DESCRIPTION
The instructions for running version 13 using ddev are currently incorrect as the old instructions from before version 12 get displayed. This PR attempts to fix that.