### PR TITLE
[TASK] Update DDEV instructions across versions

### DIFF
--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -36,7 +36,7 @@
                                 <p><a href="https://ddev.readthedocs.io/en/stable/" title="DDEV Documentation" target="_blank" rel="noopener">DDEV</a> simplifies integrating the power and consistency of containerization into your workflows. Set up environments in minutes; switch contexts and projects quickly and easily; speed your time to deployment. DDEV handles the complexity. You get on with the valuable part of your job.</p>
                                 <p><b>Before proceeding, make sure your DDEV installation is up to date.</b></p>
                                 <p>In a new project folder using your favorite shell, run these lines:</p>
-                                <pre><code>ddev config --project-type=typo3 --docroot=public --create-docroot{{ php_version_option }}
+                                <pre><code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }}
 ddev composer create --no-install "typo3/cms-base-distribution:^{{ package_version }}"
 ddev composer install
 {% if version == 12 %}
@@ -53,7 +53,7 @@ ddev launch</code></pre>
                                     <pre><code>winpty ddev typo3cms install:setup</code></pre>
                                 </div>
                                 <p>If you are experienced with Composer you can create your own composer.json and select the needed packages of TYPO3 via the <a href="{{ path('composer-helper') }}" title="Composer Helper">Composer Helper</a>. Instead of the <code>ddev composer create</code> command above, run the command created with the Composer Helper prepended with <code>ddev</code>. E.g.:</p>
-                                <pre><code>ddev config --project-type=typo3 --docroot=public --create-docroot{{ php_version_option }}
+                                <pre><code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }}
 ddev composer require "typo3/cms-core:^{{ package_version }}" "typo3/minimal:^{{ package_version }}" ...
 ddev typo3cms install:setup (if the TYPO3 Console is installed)
 ddev launch</code></pre>

--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -56,7 +56,17 @@ ddev exec touch public/FIRST_INSTALL
 ddev launch</code></pre>
                                 <div class="alert alert-warning" role="alert">
                                     <p class="font-weight-bold">Important note for Git Bash users on Windows using the default terminal MSYS2, don't forget to prepend winpty to interactive commands:</p>
-                                    <pre><code>winpty ddev typo3cms install:setup</code></pre>
+                                    <pre>
+                                    {% if console %}
+                                        {% if version == 10 %}
+                                            <code>winpty ddev typo3cms install:setup</code>
+                                        {% else %}
+                                            <code>winpty ddev typo3 install:setup</code>
+                                        {% endif %}
+                                    {% else version >= 12 %}
+                                        <code>winpty ddev typo3 setup</code>
+                                    {% endif %}
+                                    </pre>
                                 </div>
                                 <p>If you are experienced with Composer you can create your own composer.json and select the needed packages of TYPO3 via the <a href="{{ path('composer-helper') }}" title="Composer Helper">Composer Helper</a>. Instead of the <code>ddev composer create</code> command above, run the command created with the Composer Helper prepended with <code>ddev</code>. E.g.:</p>
                                 <pre><code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }}

--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -43,7 +43,13 @@ ddev composer install
 ddev restart
 {% endif %}
 {% if console %}
+{% if version == 10 %}
 ddev typo3cms install:setup
+{% else %}
+ddev typo3 install:setup
+{% endif %}
+{% elseif version >= 12 %}
+ddev typo3 setup
 {% else %}
 ddev exec touch public/FIRST_INSTALL
 {% endif %}
@@ -55,7 +61,17 @@ ddev launch</code></pre>
                                 <p>If you are experienced with Composer you can create your own composer.json and select the needed packages of TYPO3 via the <a href="{{ path('composer-helper') }}" title="Composer Helper">Composer Helper</a>. Instead of the <code>ddev composer create</code> command above, run the command created with the Composer Helper prepended with <code>ddev</code>. E.g.:</p>
                                 <pre><code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }}
 ddev composer require "typo3/cms-core:^{{ package_version }}" "typo3/minimal:^{{ package_version }}" ...
+{% if console %}
+{% if version == 10 %}
 ddev typo3cms install:setup (if the TYPO3 Console is installed)
+{% else %}
+ddev typo3 install:setup (if the TYPO3 Console is installed)
+{% endif %}
+{% elseif version >= 12 %}
+ddev typo3 setup
+{% else %}
+ddev exec touch public/FIRST_INSTALL
+{% endif %}
 ddev launch</code></pre>
                             </div>
                         </div>


### PR DESCRIPTION
1) The ddev `--create-docroot` flag has been deprecated and is no longer required in ddev
2) The section `ddev typo3cms install:setup` from the DDEV installation guide should change as follows:
Version <= 10 → `ddev typo3cms install:setup`
Version 11 → `ddev typo3 install:setup`
Version 12 → `ddev typo3 setup` (without TYPO3-Console)
Version 13 → `ddev typo3 setup` (without TYPO3-Console)