### PR TITLE
[TASK] Link to talk.typo3.org instead of Slack in footer

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -21,8 +21,8 @@
                 <p class="lead">
                     Questions about the TYPO3 CMS?
                 </p>
-                <a class="btn btn-dark" href="https://my.typo3.org/about-mytypo3org/slack" target="_blank" rel="noopener">
-                    Ask the community at Slack
+                <a class="btn btn-dark" href="https://talk.typo3.org/c/typo3-questions/" target="_blank" rel="noopener">
+                    Ask the community at TYPO3 Talk
                 </a>
                 <a class="btn btn-dark" href="https://stackoverflow.com/search?q=typo3" target="_blank" rel="noopener">
                     Ask at Stack Overflow


### PR DESCRIPTION
In line with https://github.com/TYPO3-Documentation/TYPO3CMS-Exceptions/pull/156, this also replaces the link to Slack in the footer of get.typo3.org with a link to TYPO3 Talk, reasoning being:

> This decision was made by @mabolek, since we want to get people to post their questions on https://talk.typo3.org primarily, so they are publicly searchable and indexable. This leads to less repeatedly asked questions, as happening in Slack (or other places that rely on real-time communications).