### PR TITLE
[TASK] Update ddev installation instruction for TYPO3 >=12

### DIFF
--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -40,7 +40,7 @@
                                 <p><b>Before proceeding, make sure your DDEV installation is up to date.</b></p>
                                 <p>In a new project folder using your favorite shell, run these lines:</p>
                                 <pre style="white-space: pre-line;">
-                                    <code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }}
+                                    <code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }} --webserver-type 'apache-fpm'
                                     ddev composer create --no-install "typo3/cms-base-distribution:^{{ package_version }}"
                                     ddev composer install
                                     {% if version == 12 %}
@@ -53,11 +53,12 @@
                                             ddev typo3 install:setup
                                         {% endif %}
                                     {% elseif version >= 12 %}
-                                        ddev typo3 setup
+                                        ddev typo3 setup --server-type=apache --driver=mysqli --host=db --port=3306 --dbname=db --username=db --password=db
+                                        ddev restart
                                     {% else %}
                                         ddev exec touch public/FIRST_INSTALL
                                     {% endif %}
-                                    ddev launch
+                                    ddev launch /typo3/
                                 </code></pre>
                                 <div class="alert alert-warning" role="alert">
                                     <p class="font-weight-bold">Important note for Git Bash users on Windows using the default terminal MSYS2, don't forget to prepend winpty to interactive commands:</p>
@@ -75,7 +76,7 @@
                                 </div>
                                 <p>If you are experienced with Composer you can create your own composer.json and select the needed packages of TYPO3 via the <a href="{{ path('composer-helper') }}" title="Composer Helper">Composer Helper</a>. Instead of the <code>ddev composer create</code> command above, run the command created with the Composer Helper prepended with <code>ddev</code>. E.g.:</p>
                                 <pre style="white-space: pre-line;">
-                                    <code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }}
+                                    <code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }} --webserver-type 'apache-fpm'
                                     ddev composer require "typo3/cms-core:^{{ package_version }}" "typo3/minimal:^{{ package_version }}" ...
                                     {% if console %}
                                         {% if version == 10 %}
@@ -84,11 +85,12 @@
                                             ddev typo3 install:setup (if the TYPO3 Console is installed)
                                         {% endif %}
                                     {% elseif version >= 12 %}
-                                        ddev typo3 setup
+                                        ddev typo3 setup --server-type=apache --driver=mysqli --host=db --port=3306 --dbname=db --username=db --password=db
+                                        ddev restart
                                     {% else %}
                                         ddev exec touch public/FIRST_INSTALL
                                     {% endif %}
-                                    ddev launch
+                                    ddev launch /typo3/
                                 </code></pre>
                             </div>
                         </div>


### PR DESCRIPTION
ddev recieved support to regonize changed configuration
file places and nameing for TYPO3 v12 and newer, using
composer.json input ant the pasing the `Typo3Version`
class version code to determine if a composer based
TYPO3 v12 or higher is given. That works, however it
may be necessary to restart ddev after installing our
beloved CMS which can be achieved by executing

```terminal
ddev restart
```

after the setup using cli commands. Without this, the
`additional.php` may not be written by ddev when user
tries to open the backend leading to errors realted
to missing the correct `trustedHostsPattern` needed
for `ddev`. In the past this worked without issues,
because silent upgrade migration has been run even
within the setup and installation process. Usually,
for new installation that does not make sense and
has been removed from TYPO3 for v13 and v14 with [1].

With TYPO3 v13.0 a major feature has been intruduced
which allows to configure the backend url instead of
having it fixed to `/typo3/`. That required bigger
changes and combining frontend and backend entry points
and changed to webserver configuration. For `Apache2`
this has been added and is shipped with the TYPO3
version - NGNIX and other webserver needs adjustment.

The default webserver for ddev is NGNIX and not apache2
and ddev seems not not have the required changes on
board required to satisfy a TYPO3 v13 installation.

That means that it is more than usefull to provide a
little more in the commands which users can simply
copy and paste and having a good kickstart experience
than alternativly trying to explain on `get.typo3.org`
how to change that template manually in ddev.

This change adjusts the ddev based installation
instruction for TYPO3 v12 and v13 to be usable
and working.

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/81793
