### PR TITLE
[TASK] Adjust wording for Site Package Builder

### DIFF
--- a/resources/packages/fluid_styled_content/10.4/src/Configuration/TypoScript/constants.typoscript.twig
+++ b/resources/packages/fluid_styled_content/10.4/src/Configuration/TypoScript/constants.typoscript.twig
@@ -51,6 +51,6 @@ config {
     removeDefaultJS = 0
     admPanel = 1
     prefixLocalAnchors = all
-    headerComment = build by sitepackagebuilder.com
+    headerComment = build by get.typo3.org/sitepackage
     sendCacheHeaders = 1
 }

--- a/resources/packages/fluid_styled_content/10.4/src/Resources/Public/Css/rte.css.twig
+++ b/resources/packages/fluid_styled_content/10.4/src/Resources/Public/Css/rte.css.twig
@@ -1,3 +1,3 @@
 /**
- * Created from sitepackagebuilder.com
+ * Created by get.typo3.org/sitepackage
  */

--- a/resources/packages/fluid_styled_content/11.5/src/Configuration/TypoScript/constants.typoscript.twig
+++ b/resources/packages/fluid_styled_content/11.5/src/Configuration/TypoScript/constants.typoscript.twig
@@ -51,6 +51,6 @@ config {
     removeDefaultJS = 0
     admPanel = 1
     prefixLocalAnchors = all
-    headerComment = build by sitepackagebuilder.com
+    headerComment = build by get.typo3.org/sitepackage
     sendCacheHeaders = 1
 }

--- a/resources/packages/fluid_styled_content/11.5/src/Resources/Public/Css/rte.css.twig
+++ b/resources/packages/fluid_styled_content/11.5/src/Resources/Public/Css/rte.css.twig
@@ -1,3 +1,3 @@
 /**
- * Created from sitepackagebuilder.com
+ * Created by get.typo3.org/sitepackage
  */

--- a/resources/packages/fluid_styled_content/12.4/src/Configuration/TypoScript/constants.typoscript.twig
+++ b/resources/packages/fluid_styled_content/12.4/src/Configuration/TypoScript/constants.typoscript.twig
@@ -51,6 +51,6 @@ config {
     removeDefaultJS = 0
     admPanel = 1
     prefixLocalAnchors = all
-    headerComment = build by sitepackagebuilder.com
+    headerComment = build by get.typo3.org/sitepackage
     sendCacheHeaders = 1
 }

--- a/resources/packages/fluid_styled_content/12.4/src/Resources/Public/Css/rte.css.twig
+++ b/resources/packages/fluid_styled_content/12.4/src/Resources/Public/Css/rte.css.twig
@@ -1,3 +1,3 @@
 /**
- * Created from sitepackagebuilder.com
+ * Created by get.typo3.org/sitepackage
  */

--- a/resources/packages/fluid_styled_content/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
+++ b/resources/packages/fluid_styled_content/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
@@ -24,5 +24,5 @@ config:
   removeDefaultJS: '0'
   admPanel: '1'
   prefixLocalAnchors: 'all'
-  headerComment: 'build by sitepackagebuilder.com'
+  headerComment: 'build by get.typo3.org/sitepackage'
   sendCacheHeaders: '1'

--- a/resources/packages/fluid_styled_content/13.4/src/Resources/Public/Css/rte.css
+++ b/resources/packages/fluid_styled_content/13.4/src/Resources/Public/Css/rte.css
@@ -1,3 +1,3 @@
 /**
- * Created from sitepackagebuilder.com
+ * Created by get.typo3.org/sitepackage
  */

--- a/src/Form/SitepackageType.php
+++ b/src/Form/SitepackageType.php
@@ -51,7 +51,7 @@ class SitepackageType extends AbstractType
             ->add('typo3Version', ChoiceType::class, [
                 'label' => 'TYPO3 Version',
                 'choices' => [
-                    '13.4 (Beta)' => 13.4,
+                    '13.4' => 13.4,
                     '12.4' => 12.4,
                     '11.5' => 11.5,
                     '10.4' => 10.4,
@@ -61,7 +61,7 @@ class SitepackageType extends AbstractType
             ->add('title', TextType::class, [
                 'attr' => [
                     'autocomplete' => 'off',
-                    'placeholder' => 'My Sitepackage',
+                    'placeholder' => 'My Site Package',
                 ],
             ])
             ->add('description', TextareaType::class, [
@@ -69,7 +69,7 @@ class SitepackageType extends AbstractType
                 'empty_data' => '',
                 'attr' => [
                     'autocomplete' => 'off',
-                    'placeholder' => 'Optional description for the use of this sitepackage',
+                    'placeholder' => 'Optional description for the use of this Site Package',
                 ],
             ])
             ->add('repositoryUrl', TextType::class, [

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -74,7 +74,7 @@ class MenuBuilder extends TemplateMenuBuider
             'sitepackage',
             [
                 'route' => 'sitepackage_index',
-                'label' => 'Sitepackage',
+                'label' => 'Site Package',
             ]
         );
 

--- a/templates/sitepackage/edit.html.twig
+++ b/templates/sitepackage/edit.html.twig
@@ -1,5 +1,5 @@
 {% extends '@Template/layout.html.twig' %}
-{% block title %}Edit your TYPO3 Sitepackage configuration{% endblock %}
+{% block title %}Edit your TYPO3 Site Package configuration{% endblock %}
 {% block body %}
 
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}

--- a/templates/sitepackage/index.html.twig
+++ b/templates/sitepackage/index.html.twig
@@ -3,22 +3,22 @@
 {% block body %}
 
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}
-        <h1>Sitepackage Builder</h1>
+        <h1>Site Package Builder</h1>
         <p class="lead">
-            Sitepackage-Builder is your kickstarter for modern TYPO3 Theme development. Learn more about TYPO3 templating
+            Site Package Builder is your kickstarter for modern TYPO3 Theme development. Learn more about TYPO3 templating
             or start your own template right now.
         </p>
         <p>
-            <a href="{{ path('sitepackage_new') }}" class="btn btn-lg btn-primary">Create Sitepackage</a>
+            <a href="{{ path('sitepackage_new') }}" class="btn btn-lg btn-primary">Create Site Package</a>
         </p>
     {% endframe %}
 
     {% frame with { center: true, indent: true } %}
-        <h2>What is a Sitepackage?</h2>
+        <h2>What is a Site Package?</h2>
         <p>
-            A Sitepackage is a <strong>TYPO3 Extension</strong> that containers all relevant configuration for a Website.
+            A Site Package is a <strong>TYPO3 Extension</strong> that containers all relevant configuration for a Website.
             Having all configuration stored in a package keeps it protected from unauthorized access.
-            As Extension your Sitepackage will manage your dependencies to other Extensions and/or the TYPO3 Version.
+            As Extension your Site Package will manage your dependencies to other Extensions and/or the TYPO3 Version.
             This will ease your deployment and enables you to put the configuration of your Webiste under Version Control.
         </p>
         <p>
@@ -26,16 +26,16 @@
         </p>
         <p>
             <a href="https://docs.typo3.org/permalink/t3sitepackage:start" class="btn btn-primary" target="_blank">
-                Learn about Sitepackages
+                Learn about Site Packages
             </a>
         </p>
     {% endframe %}
 
     {% frame with { color: 'dark', layout: 'embedded', center: true, indent: true } %}
-        <h2>Start your own Sitepackage</h2>
+        <h2>Start your own Site Package</h2>
         <p>
             <a href="{{ path('sitepackage_new') }}" class="btn btn-primary">
-                Create Sitepackage
+                Create Site Package
             </a>
         </p>
     {% endframe %}

--- a/templates/sitepackage/index.html.twig
+++ b/templates/sitepackage/index.html.twig
@@ -16,10 +16,10 @@
     {% frame with { center: true, indent: true } %}
         <h2>What is a Site Package?</h2>
         <p>
-            A Site Package is a <strong>TYPO3 Extension</strong> that contain all the configuration for a Website.
-            Having all configuration stored in a package keeps it protected from unauthorized access.
-            Packaged as an Extension your Site Package will manage dependencies to other Extensions and/or the TYPO3 Version.
-            This will make deployment easier and enable you to put the configuration of your Website under Version Control.
+            A site package is a <strong>TYPO3 extension</strong> that contains all the configuration for a website.
+            Having configuration stored in a package keeps it protected from unauthorized access.
+            Packaged as an extension, your site package will manage dependencies to other extensions and/or the TYPO3 version.
+            This will make deployment easier and enable you to put the configuration of your website under version control.
         </p>
         <p>
             Learn more about <strong>best practices</strong> recommended by the TYPO3 Core Team.

--- a/templates/sitepackage/index.html.twig
+++ b/templates/sitepackage/index.html.twig
@@ -6,7 +6,7 @@
         <h1>Site Package Builder</h1>
         <p class="lead">
             Site Package Builder is your kickstarter for modern TYPO3 Theme development. Learn more about TYPO3 templating
-            or start your own template right now.
+            or kickstart your own template right now.
         </p>
         <p>
             <a href="{{ path('sitepackage_new') }}" class="btn btn-lg btn-primary">Create Site Package</a>
@@ -16,13 +16,13 @@
     {% frame with { center: true, indent: true } %}
         <h2>What is a Site Package?</h2>
         <p>
-            A Site Package is a <strong>TYPO3 Extension</strong> that containers all relevant configuration for a Website.
+            A Site Package is a <strong>TYPO3 Extension</strong> that contain all the configuration for a Website.
             Having all configuration stored in a package keeps it protected from unauthorized access.
-            As Extension your Site Package will manage your dependencies to other Extensions and/or the TYPO3 Version.
-            This will ease your deployment and enables you to put the configuration of your Webiste under Version Control.
+            Packaged as an Extension your Site Package will manage dependencies to other Extensions and/or the TYPO3 Version.
+            This will make deployment easier and enable you to put the configuration of your Website under Version Control.
         </p>
         <p>
-            Learn more about the <strong>best practices</strong> recommended from the TYPO3 Core Team.
+            Learn more about <strong>best practices</strong> recommended by the TYPO3 Core Team.
         </p>
         <p>
             <a href="https://docs.typo3.org/permalink/t3sitepackage:start" class="btn btn-primary" target="_blank">

--- a/templates/sitepackage/new.html.twig
+++ b/templates/sitepackage/new.html.twig
@@ -5,8 +5,8 @@
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}
         <h1>Create your very own Site Package</h1>
         <p class="lead">
-            Awesome - you made it here! Just a bit more Information is required about your Project and your very own Site
-            Package will be ready to download.
+            Awesome - you made it here! We just need a bit more information about your project and then your very own site
+            package will be ready to download.
         </p>
     {% endframe %}
 

--- a/templates/sitepackage/new.html.twig
+++ b/templates/sitepackage/new.html.twig
@@ -1,11 +1,11 @@
 {% extends '@Template/layout.html.twig' %}
-{% block title %}Create your very own TYPO3 Sitepackage{% endblock %}
+{% block title %}Create your very own TYPO3 Site Package{% endblock %}
 {% block body %}
 
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}
-        <h1>Create your very own Sitepackage</h1>
+        <h1>Create your very own Site Package</h1>
         <p class="lead">
-            Awesome you made it here! Just a few more Information about your Project and your very own Sitepackage is ready to download.
+            Awesome you made it here! Just a few more Information about your Project and your very own Site Package is ready to download.
         </p>
     {% endframe %}
 

--- a/templates/sitepackage/new.html.twig
+++ b/templates/sitepackage/new.html.twig
@@ -5,7 +5,8 @@
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}
         <h1>Create your very own Site Package</h1>
         <p class="lead">
-            Awesome you made it here! Just a few more Information about your Project and your very own Site Package is ready to download.
+            Awesome - you made it here! Just a bit more Information is required about your Project and your very own Site
+            Package will be ready to download.
         </p>
     {% endframe %}
 

--- a/templates/sitepackage/success.html.twig
+++ b/templates/sitepackage/success.html.twig
@@ -5,8 +5,8 @@
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}
         <h1>Congratulations!</h1>
         <p class="lead">
-            We have successfully generated your Site Package. You can review the generated configuration below, or
-            download your Site Package.
+            We have successfully generated your site package. You can review the generated configuration below, or
+            download your site package.
         </p>
         <a href="{{ path('sitepackage_download') }}" class="btn btn-lg btn-primary">
             <span class="btn-text">Download</span>

--- a/templates/sitepackage/success.html.twig
+++ b/templates/sitepackage/success.html.twig
@@ -5,7 +5,8 @@
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}
         <h1>Congratulations!</h1>
         <p class="lead">
-            We have successfully generated your Site Package. You can now review the generated configuration below, or download the prepared Site Package.
+            We have successfully generated your Site Package. You can review the generated configuration below, or
+            download your Site Package.
         </p>
         <a href="{{ path('sitepackage_download') }}" class="btn btn-lg btn-primary">
             <span class="btn-text">Download</span>

--- a/templates/sitepackage/success.html.twig
+++ b/templates/sitepackage/success.html.twig
@@ -5,7 +5,7 @@
     {% frame with { color: 'dark', height: 'small', center: true, indent: true, backgroundImage: asset("assets/Images/keyvisual.png") } %}
         <h1>Congratulations!</h1>
         <p class="lead">
-            We have sucessfully generated your sitepackage. You can now review the generated configuration below, or download the prepared sitepackage.
+            We have successfully generated your Site Package. You can now review the generated configuration below, or download the prepared Site Package.
         </p>
         <a href="{{ path('sitepackage_download') }}" class="btn btn-lg btn-primary">
             <span class="btn-text">Download</span>


### PR DESCRIPTION
* Across the documentation we spell it Site Package and Site Package Builder.
* Unify case of Site Package Builder, also no hyphens
* Remove unsupported TYPO3 versions from form, templates were already missing
* Mark versions as stable etc
* Rename Fluid Styled Content into "Minimal Site Package" to make clear this is not a complete theme.