### PR TITLE
[TASK] Make author fields optional in Site Package Builder

### DIFF
--- a/src/Controller/SitePackageController.php
+++ b/src/Controller/SitePackageController.php
@@ -54,7 +54,7 @@ class SitePackageController extends AbstractController
         $form = $this->createNewSitePackageForm($sitepackage);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $sitepackage->setVendorName(StringUtility::stringToUpperCamelCase($sitepackage->getAuthor()->getCompany()));
+            $sitepackage->setVendorName(StringUtility::stringToUpperCamelCase($sitepackage->getVendorName()));
             $sitepackage->setVendorNameAlternative(StringUtility::camelCaseToLowerCaseDashed($sitepackage->getVendorName()));
             $sitepackage->setPackageName(StringUtility::stringToUpperCamelCase($sitepackage->getTitle()));
             $sitepackage->setPackageNameAlternative(StringUtility::camelCaseToLowerCaseDashed($sitepackage->getPackageName()));
@@ -90,7 +90,6 @@ class SitePackageController extends AbstractController
         $form = $this->createEditSitePackageForm($sitepackage);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $sitepackage->setVendorName(StringUtility::stringToUpperCamelCase($sitepackage->getAuthor()->getCompany()));
             $sitepackage->setVendorNameAlternative(StringUtility::camelCaseToLowerCaseDashed($sitepackage->getVendorName()));
             $sitepackage->setPackageName(StringUtility::stringToUpperCamelCase($sitepackage->getTitle()));
             $sitepackage->setPackageNameAlternative(StringUtility::camelCaseToLowerCaseDashed($sitepackage->getPackageName()));

--- a/src/Entity/SitePackage.php
+++ b/src/Entity/SitePackage.php
@@ -36,14 +36,17 @@ class SitePackage implements \JsonSerializable
     #[Assert\NotBlank]
     private float $typo3Version = 13.4;
 
-    private string $vendorName;
-
     private string $vendorNameAlternative;
 
     #[Assert\NotBlank(message: 'Please enter a title for your site package')]
     #[Assert\Length(min: 3)]
     #[Assert\Regex(pattern: '/^[A-Za-z0-9\x7f-\xff .:&-]+$/', message: 'Only letters, numbers and spaces are allowed')]
     private string $title;
+
+    #[Assert\NotBlank(message: 'Please enter a vendor, CamelCase')]
+    #[Assert\Length(min: 3)]
+    #[Assert\Regex(pattern: '/^[A-Za-z0-9]+$/', message: 'Only letters and numbers are allowed')]
+    private string $vendorName;
 
     #[Assert\Regex(pattern: '/^[A-Za-z0-9\x7f-\xff .,:!?&-]+$/', message: 'Only letters, numbers and spaces are allowed')]
     private string $description;

--- a/src/Entity/SitePackage/Author.php
+++ b/src/Entity/SitePackage/Author.php
@@ -30,20 +30,14 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Author implements \JsonSerializable
 {
-    #[Assert\NotBlank(message: "Please enter the authors' name.")]
-    #[Assert\Length(min: 3)]
     private string $name;
 
-    #[Assert\NotBlank(message: "Please enter the authors' email address.")]
     #[Assert\Email(message: "The email '{{ value }}' is not a valid email.")]
     private string $email;
 
-    #[Assert\NotBlank(message: "Please enter the authors' company.")]
-    #[Assert\Length(min: 3)]
-    #[Assert\Regex(pattern: '/^[A-Za-z0-9\x7f-\xff .:&-]+$/', message: 'Only letters, numbers and spaces are allowed')]
+    #[Assert\Regex(pattern: '/^[\p{L}\p{N} .:&-]+$/u', message: 'Invalid characters in company name.')]
     private string $company;
 
-    #[Assert\NotBlank(message: "Please enter the authors' homepage URL.")]
     #[Assert\Url]
     private string $homepage;
 

--- a/src/Form/AuthorType.php
+++ b/src/Form/AuthorType.php
@@ -36,6 +36,8 @@ class AuthorType extends AbstractType
     {
         $builder
             ->add('name', TextType::class, [
+                'required' => false,
+                'empty_data' => '',
                 'attr' => [
                     'autocomplete' => 'off',
                     'placeholder' => 'John Doe',
@@ -45,6 +47,8 @@ class AuthorType extends AbstractType
                 ],
             ])
             ->add('email', EmailType::class, [
+                'required' => false,
+                'empty_data' => '',
                 'attr' => [
                     'autocomplete' => 'off',
                     'placeholder' => 'john.doe@example.com',
@@ -54,6 +58,8 @@ class AuthorType extends AbstractType
                 ],
             ])
             ->add('company', TextType::class, [
+                'required' => false,
+                'empty_data' => '',
                 'attr' => [
                     'autocomplete' => 'off',
                     'placeholder' => 'Company Inc.',
@@ -63,6 +69,8 @@ class AuthorType extends AbstractType
                 ],
             ])
             ->add('homepage', TextType::class, [
+                'required' => false,
+                'empty_data' => '',
                 'attr' => [
                     'autocomplete' => 'off',
                     'placeholder' => 'https://www.example.com',

--- a/src/Form/SitePackageType.php
+++ b/src/Form/SitePackageType.php
@@ -78,7 +78,16 @@ class SitePackageType extends AbstractType
                     'placeholder' => 'My Site Package',
                 ],
                 'documentation' => [
-                    'example' => 'My SitePackage',
+                    'example' => 'My Site Package',
+                ],
+            ])
+            ->add('vendor_name', TextType::class, [
+                'attr' => [
+                    'autocomplete' => 'off',
+                    'placeholder' => 'MyCompany',
+                ],
+                'documentation' => [
+                    'example' => 'MyCompany',
                 ],
             ])
             ->add('description', TextareaType::class, [

--- a/templates/sitepackage/success.html.twig
+++ b/templates/sitepackage/success.html.twig
@@ -122,17 +122,27 @@
             <dt class="col-sm-3">Composer</dt>
             <dd class="col-sm-9">{{ sitepackage.vendorNameAlternative }}/{{ sitepackage.packageNameAlternative }}</dd>
         </dl>
-        <h3>Author</h3>
-        <dl class="row">
-            <dt class="col-sm-3">Name</dt>
-            <dd class="col-sm-9">{{ sitepackage.author.name }}</dd>
-            <dt class="col-sm-3">E-Mail</dt>
-            <dd class="col-sm-9">{{ sitepackage.author.email }}</dd>
-            <dt class="col-sm-3">Company</dt>
-            <dd class="col-sm-9">{{ sitepackage.author.company }}</dd>
-            <dt class="col-sm-3">Homepage</dt>
-            <dd class="col-sm-9">{{ sitepackage.author.homepage }}</dd>
-        </dl>
+        {%- if sitepackage.author.name or sitepackage.author.email or sitepackage.author.company or sitepackage.author.homepage  %}
+            <h3>Author</h3>
+            <dl class="row">
+                {%- if sitepackage.author.name  %}
+                <dt class="col-sm-3">Name</dt>
+                <dd class="col-sm-9">{{ sitepackage.author.name }}</dd>
+                {%- endif %}
+                {%- if sitepackage.author.email  %}
+                <dt class="col-sm-3">E-Mail</dt>
+                <dd class="col-sm-9">{{ sitepackage.author.email }}</dd>
+                {%- endif %}
+                {%- if sitepackage.author.company  %}
+                <dt class="col-sm-3">Company</dt>
+                <dd class="col-sm-9">{{ sitepackage.author.company }}</dd>
+                {%- endif %}
+                {%- if sitepackage.author.homepage  %}
+                <dt class="col-sm-3">Homepage</dt>
+                <dd class="col-sm-9">{{ sitepackage.author.homepage }}</dd>
+                {%- endif %}
+            </dl>
+        {%- endif %}
         <p>
             <a href="{{ path('sitepackage_new') }}" class="btn btn-light">
                 <span class="btn-text">Restart</span>

--- a/tests/Functional/Controller/Api/SitePackageControllerTest.php
+++ b/tests/Functional/Controller/Api/SitePackageControllerTest.php
@@ -45,6 +45,7 @@ class SitePackageControllerTest extends ApiCase
                 'base_package' => 'bootstrap_package',
                 'typo3_version' => 13.4,
                 'title' => 'My Site Package',
+                'vendor_name' => 'MyVendor',
                 'description' => 'Project Configuration for Client',
                 'repository_url' => 'https://github.com/FriendsOfTYPO3/introduction',
                 'author' => [
@@ -85,25 +86,12 @@ class SitePackageControllerTest extends ApiCase
         $responseContent = json_decode((string)$response->getContent(), true, 512, JSON_THROW_ON_ERROR);
         self::assertSame($responseContent, [
             'errors' => [
+                'Please enter a vendor, CamelCase',
                 'typo3_version' => [
                     'The selected choice is invalid.',
                 ],
                 'title' => [
                     'Please enter a title for your site package',
-                ],
-                'author' => [
-                    'name' => [
-                        'Please enter the authors\' name.',
-                    ],
-                    'email' => [
-                        'Please enter the authors\' email address.',
-                    ],
-                    'company' => [
-                        'Please enter the authors\' company.',
-                    ],
-                    'homepage' => [
-                        'Please enter the authors\' homepage URL.',
-                    ],
                 ],
             ],
         ]);


### PR DESCRIPTION
Due to data minimization, users should not be required to enter their email address or website to use the Site Package Builder.

The vendor many ppl use is not the same
like the company name. Also not everyone works in a company (freelancers, universities, ..) and some customers or organizations want their own vendor no matter who created the site package.

Make vendor its own field.