### PR TITLE
[TASK] Display information on how to install Site Package on success page

### DIFF
--- a/templates/sitepackage/partials/typoscript-provider.twig
+++ b/templates/sitepackage/partials/typoscript-provider.twig
@@ -1,0 +1,7 @@
+{% if sitepackage.typo3Version > 13 %}
+    <p>Include the Set "{{ sitepackage.title }}" in your site configuration.
+        See also <a href="https://docs.typo3.org/permalink/t3sitepackage:minimal-extension-siteset@{{ sitepackage.typo3Version }}">Create a basic site set</a>.</p>
+{% else %}
+    <p>Include the TypoScript Set "{{ sitepackage.title }}" in the TypoScript record of your root page:
+        <a href="https://docs.typo3.org/permalink/t3sitepackage:typo3-backend-typoscript-template@{{ sitepackage.typo3Version }}">TypoScript template</a></p>
+{% endif %}

--- a/templates/sitepackage/success.html.twig
+++ b/templates/sitepackage/success.html.twig
@@ -12,7 +12,7 @@
         </a>
     {% endframe %}
     {% if sitepackage.typo3Version > 12 %}
-        {% frame with { indent: true, id: 'sitepackage-installation', title: 'Install the Site Package' } %}
+        {% frame with { indent: true, id: 'sitepackage-installation', title: 'Install the Site Package', color: 'lighter' } %}
             <div class="accordion" id="accordion-installation">
                 <div class="accordion-item card">
                     <div class="accordion-header card-header" id="accordion-heading-composer">

--- a/templates/sitepackage/success.html.twig
+++ b/templates/sitepackage/success.html.twig
@@ -11,6 +11,63 @@
             <span class="btn-text">Download</span>
         </a>
     {% endframe %}
+    {% if sitepackage.typo3Version > 12 %}
+        {% frame with { indent: true, id: 'sitepackage-installation', title: 'Install the Site Package' } %}
+            <div class="accordion" id="accordion-installation">
+                <div class="accordion-item card">
+                    <div class="accordion-header card-header" id="accordion-heading-composer">
+                        <h4 class="accordion-title">
+                            <a href="#accordion-composer" class="accordion-title-link collapsed" data-bs-toggle="collapse" data-bs-parent="#accordion-installation" aria-expanded="true" aria-controls="accordion-installation">
+                                <span class="accordion-title-link-text">
+                                    Composer-based TYPO3 installation
+                                </span>
+                                <span class="accordion-title-link-state"></span>
+                            </a>
+                        </h4>
+                    </div>
+                    <div id="accordion-composer" class="accordion-collapse collapse" aria-labelledby="accordion-heading-composer" data-bs-parent="#accordion-installation">
+                        <div class="accordion-body card-body">
+                            <div class="accordion-content">
+                                <div class="accordion-content-item accordion-content-text">
+                                    <p>Download the Site Package and save it into folder
+                                        <a href="https://docs.typo3.org/permalink/t3coreapi:directory-packages@{{ sitepackage.typo3Version }}">packages</a>
+                                        in the root of your TYPO3 installation.</p>
+                                    <p>Require the Site Package using Composer: </p>
+                                    <pre style="white-space: pre-line;">
+                                        <code>composer req {{ sitepackage.vendorNameAlternative }}/{{ sitepackage.packageNameAlternative }}</code>
+                                    </pre>
+                                    {% include 'sitepackage/partials/typoscript-provider.twig' %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="accordion-header card-header" id="accordion-heading-classic">
+                        <h4 class="accordion-title">
+                            <a href="#accordion-classic" class="accordion-title-link collapsed" data-bs-toggle="collapse" data-bs-parent="#accordion-installation" aria-expanded="false" aria-controls="accordion-classic">
+                                <span class="accordion-title-link-text">
+                                    Classic TYPO3 installation
+                                </span>
+                                <span class="accordion-title-link-state"></span>
+                            </a>
+                        </h4>
+                    </div>
+                    <div id="accordion-classic" class="accordion-collapse collapse" aria-labelledby="accordion-heading-classic" data-bs-parent="#accordion-installation">
+                        <div class="accordion-body card-body">
+                            <div class="accordion-content">
+                                <div class="accordion-content-item accordion-content-text">
+                                    <p>Download the Site Package and save it into folder
+                                        <a href="https://docs.typo3.org/permalink/t3coreapi:legacy-directory-typo3conf-ext@{{ sitepackage.typo3Version }}">typo3conf/ext/</a>
+                                        in the root of your TYPO3 installation.</p>
+                                    <p>Activate extension "{{ sitepackage.title }}" with key {{ sitepackage.extensionKey }} in the Extension Manager. </p>
+                                    {% include 'sitepackage/partials/typoscript-provider.twig' %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endframe %}
+    {% endif %}
 
     {% frame with { indent: true } %}
         <h2>Generated Configuration</h2>


### PR DESCRIPTION
Only added for current LTS versions, in the other versions some of the links do not yet work

![image](https://github.com/user-attachments/assets/546823ab-5a22-48e9-8e90-fad41603d02e)
