### PR TITLE
[BUGFIX] Use lowercase for all backend layouts

### DIFF
--- a/resources/packages/site_package_tutorial/13.4/src/Configuration/Sets/SitePackage/PageTsConfig/BackendLayouts/subpage.tsconfig.twig
+++ b/resources/packages/site_package_tutorial/13.4/src/Configuration/Sets/SitePackage/PageTsConfig/BackendLayouts/subpage.tsconfig.twig
@@ -4,7 +4,7 @@
 mod {
     web_layout {
         BackendLayouts {
-            Subpage {
+            subpage {
                 title = LLL:EXT:{{ package.extensionKey }}/Resources/Private/Language/locallang_be.xlf:backend_layout.subpage
                 config {
                     backend_layout {

--- a/resources/packages/site_package_tutorial/13.4/src/Initialisation/data.xml
+++ b/resources/packages/site_package_tutorial/13.4/src/Initialisation/data.xml
@@ -590,8 +590,8 @@
 				<field index="mount_pid_ol" type="integer">0</field>
 				<field index="module"></field>
 				<field index="l18n_cfg" type="integer">0</field>
-				<field index="backend_layout">pagets__Default</field>
-				<field index="backend_layout_next_level">pagets__Subpage</field>
+				<field index="backend_layout">pagets__default</field>
+				<field index="backend_layout_next_level">pagets__subpage</field>
 				<field index="tsconfig_includes"></field>
 				<field index="seo_title"></field>
 				<field index="no_index" type="integer">0</field>


### PR DESCRIPTION
We currently have one in lower case, one in captital. Also data.xml and names do not allign