### PR TITLE
[TASK] Add prominent demo button to "Try it online" section for bette…

### DIFF
--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -221,7 +221,7 @@
         <p>
             Want to explore TYPO3 right away without installing anything? In the online demo, you can try out a full
             TYPO3 installation, access the backend, and even make changes and see the result.
-            All changes will be reset after 30 minutes..
+            All changes will be reset after 30 minutes.
         </p>
         <p>
             <a href="https://demo.typo3.org" class="btn btn-primary btn-lg" target="_blank" rel="noopener">

--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -219,8 +219,18 @@
 
     {% frame with { id: 'try-online', color: 'lighter', indent: true, center: true, title: 'Try it online', titleSize: 3 } %}
         <p>
-            Install a complete Apache / MySQL / PHP environment with a TYPO3 package remotely as a SAAS / cloud
-            based infrastructures to get started as quick as possible.
+            Want to explore TYPO3 right away without installing anything? In the online demo, you can try out a full
+            TYPO3 installation, access the backend, and even make changes and see the result.
+            All changes will be reset after 30 minutes..
+        </p>
+        <p>
+            <a href="https://demo.typo3.org" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
+                Go to the TYPO3 online Demo
+            </a>
+        </p>
+        <p>
+            Or, install a complete Apache / MySQL / PHP environment with a TYPO3 package remotely as a SaaS/cloud-based
+            infrastructure to get started quickly.
         </p>
     {% endframe %}
     {% frame with { color: 'light' } %}


### PR DESCRIPTION
…r onboarding

![image](https://github.com/user-attachments/assets/6ff9f5a5-bef9-41a5-980c-b837c6ef39eb)


- Added a clear call-to-action button linking to https://demo.typo3.org
- Clarified the purpose of the online demo and what users can expect
- Improved accessibility for newcomers by aligning expectations with the button label ("Go to the TYPO3 online Demo")
- Helps new users quickly try TYPO3 without needing a full installation

Contributes to strategic goals:
Goal No. 4 – Improve customer-oriented communication Technical Subgoal 4.3 - solution-oriented communication and documentation