### PR TITLE
[TASK] Link to dedicated documentation pages for installation method

### DIFF
--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -39,9 +39,8 @@
                                 {% if version >= 11 %}
                                     <p>To the detailed instructions in <a href="https://docs.typo3.org/permalink/t3start:installation-ddev-tutorial@{{ version }}" title="DDEV Documentation" target="_blank" rel="noopener">Getting Started, Installing TYPO3 with DDEV</a></p>
                                 {% endif %}
-                                xxx
                                 <p><a href="https://ddev.readthedocs.io/en/stable/" title="DDEV Documentation" target="_blank" rel="noopener">DDEV</a> simplifies integrating the power and consistency of containerization into your workflows. Set up environments in minutes; switch contexts and projects quickly and easily; speed your time to deployment. DDEV handles the complexity. You get on with the valuable part of your job.</p>
-                                <p><b>Before proceeding, make sure your DDEV installation is up to date.</b></p>
+                                <p><b>Before proceeding, make sure your DDEV installation is up-to-date.</b></p>
                                 <p>In a new project folder using your favorite shell, run these lines:</p>
                                 <pre style="white-space: pre-line;">
                                     <code>ddev config --project-type=typo3 --docroot=public{{ php_version_option }} --webserver-type 'apache-fpm'

--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -36,6 +36,10 @@
                     <div class="accordion-body card-body">
                         <div class="accordion-content">
                             <div class="accordion-content-item accordion-content-text">
+                                {% if version >= 11 %}
+                                    <p>To the detailed instructions in <a href="https://docs.typo3.org/permalink/t3start:installation-ddev-tutorial@{{ version }}" title="DDEV Documentation" target="_blank" rel="noopener">Getting Started, Installing TYPO3 with DDEV</a></p>
+                                {% endif %}
+                                xxx
                                 <p><a href="https://ddev.readthedocs.io/en/stable/" title="DDEV Documentation" target="_blank" rel="noopener">DDEV</a> simplifies integrating the power and consistency of containerization into your workflows. Set up environments in minutes; switch contexts and projects quickly and easily; speed your time to deployment. DDEV handles the complexity. You get on with the valuable part of your job.</p>
                                 <p><b>Before proceeding, make sure your DDEV installation is up to date.</b></p>
                                 <p>In a new project folder using your favorite shell, run these lines:</p>
@@ -146,6 +150,9 @@
                                 using a client that supports Server Name Indication (SNI). This especially affects old versions
                                 of wget (before version 1.14).
                             </p>
+                            {% if version >= 12 %}
+                                <p>See also <a href="https://docs.typo3.org/permalink/t3coreapi:legacyinstallation@{{ package_version }}">TYPO3 installation with wget</a></p>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
@@ -168,6 +175,7 @@
                     <div class="accordion-content">
                         <div class="accordion-content-item accordion-content-text">
                             <pre>git clone https://github.com/typo3/typo3</pre>
+                            <p>See also <a href="https://docs.typo3.org/permalink/t3contribute:quickstart">TYPO3 contribution quick start: Get ready to contribute to TYPO3 in under 30 minutes!</a></p>
                         </div>
                     </div>
                 </div>
@@ -205,6 +213,11 @@
                                 </li>
                                 {% endif %}
                             </ul>
+
+                            {% if version >= 12 %}
+                                <p>See also <a href="https://docs.typo3.org/permalink/t3coreapi:legacyinstallation@{{ package_version }}">TYPO3 installation with tarball/zip</a></p>
+                                <p>See also <a href="https://docs.typo3.org/permalink/t3coreapi:release-integrity@{{ package_version }}">TYPO3 release integrity</a></p>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -150,7 +150,7 @@
                                 of wget (before version 1.14).
                             </p>
                             {% if version >= 12 %}
-                                <p>See also <a href="https://docs.typo3.org/permalink/t3coreapi:legacyinstallation@{{ package_version }}">TYPO3 installation with wget</a></p>
+                                <p>See also: <a href="https://docs.typo3.org/permalink/t3coreapi:legacyinstallation@{{ package_version }}" target="_blank" rel="noopener">TYPO3 installation with wget</a></p>
                             {% endif %}
                         </div>
                     </div>
@@ -174,7 +174,7 @@
                     <div class="accordion-content">
                         <div class="accordion-content-item accordion-content-text">
                             <pre>git clone https://github.com/typo3/typo3</pre>
-                            <p>See also <a href="https://docs.typo3.org/permalink/t3contribute:quickstart">TYPO3 contribution quick start: Get ready to contribute to TYPO3 in under 30 minutes!</a></p>
+                            <p>See also: <a href="https://docs.typo3.org/permalink/t3contribute:quickstart" target="_blank" rel="noopener">TYPO3 contribution quick start: Get ready to contribute to TYPO3 in under 30 minutes!</a></p>
                         </div>
                     </div>
                 </div>
@@ -214,8 +214,8 @@
                             </ul>
 
                             {% if version >= 12 %}
-                                <p>See also <a href="https://docs.typo3.org/permalink/t3coreapi:legacyinstallation@{{ package_version }}">TYPO3 installation with tarball/zip</a></p>
-                                <p>See also <a href="https://docs.typo3.org/permalink/t3coreapi:release-integrity@{{ package_version }}">TYPO3 release integrity</a></p>
+                                <p>See also: <a href="https://docs.typo3.org/permalink/t3coreapi:legacyinstallation@{{ package_version }}" target="_blank" rel="noopener">TYPO3 installation with tarball/zip</a></p>
+                                <p>See also: <a href="https://docs.typo3.org/permalink/t3coreapi:release-integrity@{{ package_version }}" target="_blank" rel="noopener">TYPO3 release integrity</a></p>
                             {% endif %}
                         </div>
                     </div>


### PR DESCRIPTION
It is confusing to users that the "Installation" page only talks about composer when they are currently trying to do a tar legacy installation.

Also who wants to contribute should be directed to the contribution guide not only to GitHub.

All links are only displayed if the page already existed for that version.