### PR TITLE
[BUGFIX] Make extensions installable in classic installations

### DIFF
--- a/src/Service/SitePackageGenerator.php
+++ b/src/Service/SitePackageGenerator.php
@@ -43,7 +43,7 @@ class SitePackageGenerator
     public function create(SitePackage $package): void
     {
         $extensionKey = $package->getExtensionKey();
-        $this->filename = $extensionKey . '.zip';
+        $this->filename = $extensionKey . '_1.0.0.zip';
         $sourceDir = $this->kernel->getProjectDir() . '/resources/packages/' . $package->getBasePackage() . '/' . (string)$package->getTypo3Version() . '/src/';
         $tempFileName = tempnam(sys_get_temp_dir(), $this->filename);
         if ($tempFileName === false) {


### PR DESCRIPTION
Currently a site package as generated by this generator cannot be installed with the extension manager in a classic installation:

https://forge.typo3.org/issues/106671

This is due to the fact that the Extension Manager expects a name scheme of the zip file like `<extension_name>_<version>.zip`

This PR adjusts the name schmeme of the generated zip to be compatible with the needs of the Extension manger