### PR TITLE
[TASK] Clarify platform.sh wording to reflect required setup steps

### DIFF
--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -258,9 +258,9 @@
                         <img src="{{ asset('assets/Images/try/platform.png') }}" alt="platform.sh">
                     </div>
                     <div class="card-body">
-                        <p>Launch a TYPO3 project on platform.sh with their managed hosting.</p>
-                        <p>Create an organization, set up your project, and follow guided steps
-                            including configuration and deployment. A CLI tool is available to assist with setup.</p>
+                        <p>Automate TYPO3 deployment on platform.sh using their DevOps workflow.</p>
+                        <p>Create an organization, set up your project, and follow guided steps to configure and
+                            deploy your TYPO3 instance. A CLI tool is available to assist with the process.</p>
                     </div>
                     <div class="card-footer">
                         <a href="https://platform.sh/marketplace/typo3/" target="_blank" rel="noopener" class="btn btn-primary">

--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -260,7 +260,8 @@
                     <div class="card-body">
                         <p>Automate TYPO3 deployment on platform.sh using their DevOps workflow.</p>
                         <p>Create an organization, set up your project, and follow guided steps to configure and
-                            deploy your TYPO3 instance. A CLI tool is available to assist with the process.</p>
+                            deploy your TYPO3 instance. A CLI tool is available to assist with the process.
+                        </p>
                     </div>
                     <div class="card-footer">
                         <a href="https://platform.sh/marketplace/typo3/" target="_blank" rel="noopener" class="btn btn-primary">

--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -258,11 +258,13 @@
                         <img src="{{ asset('assets/Images/try/platform.png') }}" alt="platform.sh">
                     </div>
                     <div class="card-body">
-                        <p>Try out TYPO3 LTS on platform.sh with one click.</p>
+                        <p><b>Launch a TYPO3 project on platform.sh with their managed hosting.</b>
+                            Create an organization, set up your project, and follow guided steps
+                            including configuration and deployment. A CLI tool is available to assist with setup.</p>
                     </div>
                     <div class="card-footer">
                         <a href="https://platform.sh/marketplace/typo3/" target="_blank" rel="noopener" class="btn btn-primary">
-                            <span class="btn-text">Go to platform.sh</span>
+                            <span class="btn-text">Start on platform.sh</span>
                         </a>
                     </div>
                 </div>

--- a/templates/default/root.html.twig
+++ b/templates/default/root.html.twig
@@ -258,8 +258,8 @@
                         <img src="{{ asset('assets/Images/try/platform.png') }}" alt="platform.sh">
                     </div>
                     <div class="card-body">
-                        <p><b>Launch a TYPO3 project on platform.sh with their managed hosting.</b>
-                            Create an organization, set up your project, and follow guided steps
+                        <p>Launch a TYPO3 project on platform.sh with their managed hosting.</p>
+                        <p>Create an organization, set up your project, and follow guided steps
                             including configuration and deployment. A CLI tool is available to assist with setup.</p>
                     </div>
                     <div class="card-footer">


### PR DESCRIPTION
The previous text implied a one-click experience which does not match the current process on platform.sh. Users are required to create an organization and follow multiple setup steps including CLI usage.

This commit updates the description to set proper expectations and changes the button label to "Start on platform.sh". A tooltip was also added to inform users about the required setup steps.