### PR TITLE
[BUGFIX] Store and process site settings.yaml as a map

### DIFF
--- a/resources/packages/bootstrap_package/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
+++ b/resources/packages/bootstrap_package/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
@@ -1,28 +1,21 @@
-plugin:
-  bootstrap_package:
-    settings:
-      scss:
-        primary: '#eb3e4a'
-        secondary: '#013859'
-    view:
-      layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Layouts/'
-      partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Partials/'
-      templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Templates/'
-  bootstrap_package_contentelements:
-    view:
-      layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Layouts/ContentElements/'
-      partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Partials/ContentElements/'
-      templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Templates/ContentElements/'
-page:
-  logo:
-    file: 'EXT:{{ package.extensionKey }}/Resources/Public/Images/logo.svg'
-    fileInverted: 'EXT:{{ package.extensionKey }}/Resources/Public/Images/logo-inverted.svg'
-    width: 192
-    alt: 'My Site Package'
-    linktitle: 'My Site Package'
-  favicon:
-    file: 'EXT:{{ package.extensionKey }}/Resources/Public/Icons/favicon.ico'
-  fluidtemplate:
-    layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Layouts/Page/'
-    partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Partials/Page/'
-    templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Templates/Page/'
+plugin.bootstrap_package.settings.scss.primary: '#eb3e4a'
+plugin.bootstrap_package.settings.scss.secondary: '#013859'
+plugin.bootstrap_package.view.layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Layouts/'
+plugin.bootstrap_package.view.partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Partials/'
+plugin.bootstrap_package.view.templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Templates/'
+
+plugin.bootstrap_package_contentelements.view.layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Layouts/ContentElements/'
+plugin.bootstrap_package_contentelements.view.partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Partials/ContentElements/'
+plugin.bootstrap_package_contentelements.view.templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Templates/ContentElements/'
+
+page.logo.file: 'EXT:{{ package.extensionKey }}/Resources/Public/Images/logo.svg'
+page.logo.fileInverted: 'EXT:{{ package.extensionKey }}/Resources/Public/Images/logo-inverted.svg'
+page.logo.width: 192
+page.logo.alt: 'My Site Package'
+page.logo.linktitle: 'My Site Package'
+
+page.favicon.file: 'EXT:{{ package.extensionKey }}/Resources/Public/Icons/favicon.ico'
+
+page.fluidtemplate.layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Layouts/Page/'
+page.fluidtemplate.partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Partials/Page/'
+page.fluidtemplate.templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/Templates/Page/'

--- a/resources/packages/fluid_styled_content/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
+++ b/resources/packages/fluid_styled_content/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
@@ -1,28 +1,20 @@
-styles:
-  templates:
-    layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Layouts/'
-    partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Partials/'
-    templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Templates/'
+styles.templates.layoutRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Layouts/'
+styles.templates.partialRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Partials/'
+styles.templates.templateRootPath: 'EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Templates/'
 
-page:
-  pageview:
-    paths: 'EXT:{{ package.extensionKey }}/Resources/Private/PageView/'
+page.pageview.paths: 'EXT:{{ package.extensionKey }}/Resources/Private/PageView/'
 
-  meta:
-    viewport: 'width=device-width, initial-scale=1'
-    robots: 'index,follow'
-    apple-mobile-web-app-capable: 'no'
-    compatible: 'IE=edge'
+page.meta.viewport: 'width=device-width, initial-scale=1'
+page.meta.robots: 'index,follow'
+page.meta.apple-mobile-web-app-capable: 'no'
+page.meta.compatible: 'IE=edge'
 
-  tracking:
-    google:
-      trackingID: ''
-      anonymizeIp: '1'
+page.tracking.google.trackingID: ''
+page.tracking.google.anonymizeIp: '1'
 
-config:
-  no_cache: '0'
-  removeDefaultJS: '0'
-  admPanel: '1'
-  prefixLocalAnchors: 'all'
-  headerComment: 'build by get.typo3.org/sitepackage'
-  sendCacheHeaders: '1'
+config.no_cache: '0'
+config.removeDefaultJS: '0'
+config.admPanel: '1'
+config.prefixLocalAnchors: 'all'
+config.headerComment: 'build by get.typo3.org/sitepackage'
+config.sendCacheHeaders: '1'

--- a/resources/packages/site_package_tutorial/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
+++ b/resources/packages/site_package_tutorial/13.4/src/Configuration/Sets/SitePackage/settings.yaml.twig
@@ -1,12 +1,7 @@
-styles:
-    templates:
-        layoutRootPath: EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Layouts
-        partialRootPath: EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Partials
-        templateRootPath: EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Templates
-    content:
-        textmedia:
-            maxW: 1200
-            maxWInText: 600
-            linkWrap:
-                lightboxEnabled: true
-                lightboxCssClass: lightbox
+styles.templates.layoutRootPath: EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Layouts
+styles.templates.partialRootPath: EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Partials
+styles.templates.templateRootPath: EXT:{{ package.extensionKey }}/Resources/Private/ContentElements/Templates
+styles.content.textmedia.maxW: 1200
+styles.content.textmedia.maxWInText: 600
+styles.content.textmedia.linkWraplightboxEnabled: true
+styles.content.textmedia.lightboxCssClass: lightbox


### PR DESCRIPTION
With https://review.typo3.org/c/Packages/TYPO3.CMS/+/89738 settings in the `settings.yaml` are expected to be stored as a map instead of tree.

See also [Important: #106894 - Site settings.yaml is now stored as a map](https://docs.typo3.org/permalink/changelog:important-106894-1750144877)

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1273