### PR TITLE
[TASK] Drop typo3/cms-setup from v14 composer helper

### DIFF
--- a/src/Service/ComposerPackagesService.php
+++ b/src/Service/ComposerPackagesService.php
@@ -516,7 +516,6 @@ final class ComposerPackagesService
             'name'        => 'typo3/cms-setup',
             'description' => 'Allows users to edit a limited set of options for their user profile, eg. preferred language and their name and email address.',
             'versions' => [
-                14,
                 13,
                 12,
                 11,


### PR DESCRIPTION
typo3/cms-setup was merged into typo3/cms-backend, see https://docs.typo3.org/permalink/changelog:important-109517-1744105200