### PR TITLE
[BUGFIX] Calculate Composer Helper version titles from version state

### DIFF
--- a/src/Entity/MajorVersion.php
+++ b/src/Entity/MajorVersion.php
@@ -203,6 +203,18 @@ class MajorVersion implements \JsonSerializable, \Stringable
         return $this->title;
     }
 
+    public function getComputedTitle(): string
+    {
+        $base = sprintf('TYPO3 %d', (int)$this->version);
+        if ($this->isElts()) {
+            return $base . ' ELTS';
+        }
+        if ($this->getLts() !== null) {
+            return $base . ' LTS';
+        }
+        return $base;
+    }
+
     public function setSubtitle(string $subtitle): void
     {
         $this->subtitle = $subtitle;

--- a/src/Service/ComposerPackagesService.php
+++ b/src/Service/ComposerPackagesService.php
@@ -818,7 +818,7 @@ final class ComposerPackagesService
         $versions = $this->majorVersions->findAllComposerSupported();
         foreach ($versions as $version) {
             if ($version->getLatestRelease() instanceof Release) {
-                $versionChoices['choices'][self::CMS_VERSIONS_GROUP][$version->getTitle()] =
+                $versionChoices['choices'][self::CMS_VERSIONS_GROUP][$version->getComputedTitle()] =
                     $this->getComposerVersionConstraint($version->getLatestRelease()->getVersion());
             }
         }
@@ -840,7 +840,7 @@ final class ComposerPackagesService
 
                 if (\is_null($version->getLatestRelease()->getMajorVersion()->getLts())) {
                     $versionChoices['choices'][self::SPECIAL_VERSIONS_GROUP]
-                        [$version->getTitle() . ' - next minor release (' . $nextMinor . ')'] =
+                        [$version->getComputedTitle() . ' - next minor release (' . $nextMinor . ')'] =
                         $this->getComposerVersionConstraint($nextMinor, true);
                 }
             } else {
@@ -848,7 +848,7 @@ final class ComposerPackagesService
             }
 
             $versionChoices['choices'][self::SPECIAL_VERSIONS_GROUP]
-                [$version->getTitle() . ' - next patch release (' . $nextPatch . ')'] =
+                [$version->getComputedTitle() . ' - next patch release (' . $nextPatch . ')'] =
                 $this->getComposerVersionConstraint($nextPatch, true);
         }
 


### PR DESCRIPTION
Instead of relying on the database title field (which can become stale when a version transitions from LTS to ELTS), derive the label dynamically via a new getComputedTitle() method on MajorVersion.