### PR TITLE
[TASK] Replace deprecated ddev composer create command

### DIFF
--- a/templates/default/partials/version/download.html.twig
+++ b/templates/default/partials/version/download.html.twig
@@ -44,7 +44,7 @@
                                 <p>In a new project folder using your favorite shell, run these lines:</p>
                                 <pre style="white-space: pre-line;">
                                     <code>ddev config --project-type='typo3' --docroot='public' {{ php_version_option }} --webserver-type='apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
-                                    ddev composer create --no-install "typo3/cms-base-distribution:^{{ package_version }}"
+                                    ddev composer create-project --no-install "typo3/cms-base-distribution:^{{ package_version }}"
                                     ddev composer install
                                     {% if version == 12 %}
                                         ddev restart


### PR DESCRIPTION
## Summary

The command shown on `https://get.typo3.org/version/13` in the section **"Set up a new project via DDEV and Composer"** used:

`ddev composer create --no-install "typo3/cms-base-distribution:^{{ package_version }}"`

This command now emits a deprecation warning:
> Command "create" is deprecated, please start using the identical "ddev composer create-project" instead

This PR updates the command to:

`ddev composer create-project --no-install "typo3/cms-base-distribution:^{{ package_version }}"`

so the instructions match current DDEV usage and TYPO3 docs:
https://docs.typo3.org/permalink/t3start:install-quick

This PR fixes #530 